### PR TITLE
Now the right local IP is shown.

### DIFF
--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/main/OverviewConnectionsActivity.java
@@ -75,6 +75,7 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
     private TrustChainDBHelper dbHelper;
     private Network network;
     private PeerHandler peerHandler;
+    private String wan = "";
 
     /**
      * Initialize views, start send and receive threads if necessary.
@@ -470,9 +471,9 @@ public class OverviewConnectionsActivity extends AppCompatActivity implements Ne
     public void updateWan(Message message) throws MessageException {
         if (peerHandler.getWanVote().vote(message.getDestination())) {
             Log.d("App-To-App Log", "Address changed to " + peerHandler.getWanVote().getAddress());
-            updateInternalSourceAddress(peerHandler.getWanVote().getAddress().toString());
+            wan = peerHandler.getWanVote().getAddress().toString();
         }
-        setWanvote(peerHandler.getWanVote().getAddress().toString());
+        setWanvote(wan);
     }
 
     @Override


### PR DESCRIPTION
When the WAN address is updated, the local IP is also updated to the same address as WAN. This is no longer the case. User can now see their local IP.